### PR TITLE
Stabilize omni-modal motion training geometry

### DIFF
--- a/configs/generation/representation/125d.yaml
+++ b/configs/generation/representation/125d.yaml
@@ -6,3 +6,4 @@ canonical_frame_idx: 9
 feat_dim: 125
 sequence_length: 60
 rotation_representation: rot6d
+rot6d_gradient_mode: canonical

--- a/src/omg/generation/denoisers/transformer.py
+++ b/src/omg/generation/denoisers/transformer.py
@@ -189,6 +189,77 @@ class LocalTemporalCrossAttention(nn.Module):
         return h
 
 
+def _qk_normalized_cross_attention(
+    attention: nn.Module,
+    query: torch.Tensor,
+    context: torch.Tensor,
+    context_key_padding_mask: torch.Tensor | None,
+) -> torch.Tensor:
+    """Cross-attend with per-head query/key directions instead of magnitudes.
+
+    QK normalization removes the otherwise unidentifiable radial degree of
+    freedom in query and key projections.  Scaling either projection therefore
+    cannot sharpen the logits or amplify the input Jacobian.  Multiplying unit
+    vectors by ``sqrt(head_dim)`` preserves the variance of standard scaled
+    dot-product attention at initialization.
+    """
+    if hasattr(attention, "_qkv_same_embed_dim") and not attention._qkv_same_embed_dim:
+        raise ValueError("QK-normalized cross-attention requires equal query/key/value dimensions")
+
+    embed_dim = attention.embed_dim
+    num_heads = attention.num_heads
+    head_dim = embed_dim // num_heads
+    if hasattr(attention, "q_proj"):
+        q = attention.q_proj(query)
+        k = attention.k_proj(context)
+        v = attention.v_proj(context)
+    else:
+        if attention.in_proj_weight is None:
+            raise ValueError("QK-normalized cross-attention requires packed projection weights")
+        weight_q, weight_k, weight_v = attention.in_proj_weight.chunk(3, dim=0)
+        if attention.in_proj_bias is None:
+            bias_q = bias_k = bias_v = None
+        else:
+            bias_q, bias_k, bias_v = attention.in_proj_bias.chunk(3, dim=0)
+        q = F.linear(query, weight_q, bias_q)
+        k = F.linear(context, weight_k, bias_k)
+        v = F.linear(context, weight_v, bias_v)
+    batch_size, query_len, _ = q.shape
+    context_len = k.shape[1]
+    q = q.view(batch_size, query_len, num_heads, head_dim).transpose(1, 2)
+    k = k.view(batch_size, context_len, num_heads, head_dim).transpose(1, 2)
+    v = v.view(batch_size, context_len, num_heads, head_dim).transpose(1, 2)
+
+    head_scale = math.sqrt(head_dim)
+    q = F.normalize(q.float(), dim=-1).to(dtype=q.dtype) * head_scale
+    k = F.normalize(k.float(), dim=-1).to(dtype=k.dtype) * head_scale
+
+    attn_mask = None
+    if context_key_padding_mask is not None:
+        attn_mask = torch.zeros(
+            batch_size,
+            1,
+            1,
+            context_len,
+            device=q.device,
+            dtype=q.dtype,
+        )
+        attn_mask = attn_mask.masked_fill(
+            context_key_padding_mask[:, None, None, :].bool(),
+            torch.finfo(q.dtype).min,
+        )
+    h = F.scaled_dot_product_attention(
+        q,
+        k,
+        v,
+        attn_mask=attn_mask,
+        dropout_p=float(getattr(attention, "dropout", 0.0)) if attention.training else 0.0,
+        is_causal=False,
+    )
+    h = h.transpose(1, 2).reshape(batch_size, query_len, embed_dim)
+    return attention.out_proj(h)
+
+
 class RotaryTransformerEncoderLayer(nn.Module):
     def __init__(self, hidden_dim: int, num_heads: int, dropout: float = 0.1, rope_base: float = 10000.0):
         super().__init__()
@@ -426,12 +497,11 @@ class MotionTransformerBlock(nn.Module):
     ) -> torch.Tensor:
         context_key_padding = ~context_mask.bool()
         h = self.norm_cross(x)
-        cross, _ = self.cross_attn(
+        cross = _qk_normalized_cross_attention(
+            self.cross_attn,
             query=h,
-            key=context,
-            value=context,
-            key_padding_mask=context_key_padding,
-            need_weights=False,
+            context=context,
+            context_key_padding_mask=context_key_padding,
         )
         x = x + self.dropout(cross)
         h = self.norm_self(x)

--- a/src/omg/generation/export/onnx.py
+++ b/src/omg/generation/export/onnx.py
@@ -73,6 +73,9 @@ class TensorRTFriendlyMultiheadAttention(nn.Module):
         q = self.q_proj(query).reshape(batch_size, query_len, self.num_heads, self.head_dim).transpose(1, 2)
         k = self.k_proj(key).reshape(batch_size, key_len, self.num_heads, self.head_dim).transpose(1, 2)
         v = self.v_proj(value).reshape(batch_size, key_len, self.num_heads, self.head_dim).transpose(1, 2)
+        head_scale = float(self.head_dim) ** 0.5
+        q = F.normalize(q.float(), dim=-1).to(dtype=q.dtype) * head_scale
+        k = F.normalize(k.float(), dim=-1).to(dtype=k.dtype) * head_scale
 
         attn_mask = None
         if key_padding_mask is not None:

--- a/src/omg/generation/losses/motion.py
+++ b/src/omg/generation/losses/motion.py
@@ -15,11 +15,20 @@ from omg.utils.rotation_conversions import (
 )
 
 
-def _masked_sum_batch_mean(value: torch.Tensor, mask: torch.Tensor) -> torch.Tensor:
+def _masked_element_mean(value: torch.Tensor, mask: torch.Tensor) -> torch.Tensor:
+    """Average every valid scalar while keeping samples equally weighted.
+
+    Motion terms have different event shapes: root positions contain three
+    coordinates, joint losses contain one value per joint, and FK losses add a
+    body dimension.  Counting only valid frames makes those trailing dimensions
+    implicit multipliers on the objective.  That is inconsistent with the
+    diffusion objective, which averages its feature dimension explicitly.
+    """
     mask = mask.to(device=value.device, dtype=value.dtype)
-    denominator = mask.flatten(1).sum(dim=1)
     while mask.ndim < value.ndim:
         mask = mask.unsqueeze(-1)
+    mask = mask.expand_as(value)
+    denominator = mask.flatten(1).sum(dim=1)
     per_sample = (value * mask).flatten(1).sum(dim=1) / denominator.clamp_min(1.0)
     has_values = denominator > 0
     if not has_values.any():
@@ -164,10 +173,10 @@ class MotionLoss(nn.Module):
         gt = representation.codec.split_features(target_features.to(pred_features.device))
         zero = pred_features.new_zeros(())
         terms = {
-            "simple_root_pos_loss": _masked_sum_batch_mean((pred.root_pos_local - gt.root_pos_local).pow(2), valid),
-            "simple_root_rot_loss": _masked_sum_batch_mean(_quat_geodesic_sq(pred.root_rot_local_quat, gt.root_rot_local_quat), valid),
-            "simple_joint_dof_loss": _masked_sum_batch_mean((pred.joint_dof - gt.joint_dof).pow(2), valid),
-            "simple_body_pos_loss": _masked_sum_batch_mean((pred.body_link_pos_local - gt.body_link_pos_local).pow(2), valid[:, :, None]),
+            "simple_root_pos_loss": _masked_element_mean((pred.root_pos_local - gt.root_pos_local).pow(2), valid),
+            "simple_root_rot_loss": _masked_element_mean(_quat_geodesic_sq(pred.root_rot_local_quat, gt.root_rot_local_quat), valid),
+            "simple_joint_dof_loss": _masked_element_mean((pred.joint_dof - gt.joint_dof).pow(2), valid),
+            "simple_body_pos_loss": _masked_element_mean((pred.body_link_pos_local - gt.body_link_pos_local).pow(2), valid[:, :, None]),
             "body_pos_consistency_loss": zero,
             "vel_root_pos_loss": zero,
             "vel_root_rot_loss": zero,
@@ -186,15 +195,15 @@ class MotionLoss(nn.Module):
 
         if pred_features.shape[1] > 1:
             pair_mask = valid[:, 1:] & valid[:, :-1]
-            terms["vel_root_pos_loss"] = _masked_sum_batch_mean(
+            terms["vel_root_pos_loss"] = _masked_element_mean(
                 (torch.diff(pred.root_pos_local, dim=1) - torch.diff(gt.root_pos_local, dim=1)).pow(2),
                 pair_mask,
             )
-            terms["vel_root_rot_loss"] = _masked_sum_batch_mean(
+            terms["vel_root_rot_loss"] = _masked_element_mean(
                 (_quat_velocity(pred.root_rot_local_quat, fps) - _quat_velocity(gt.root_rot_local_quat, fps)).pow(2),
                 pair_mask,
             )
-            terms["vel_joint_dof_loss"] = _masked_sum_batch_mean(
+            terms["vel_joint_dof_loss"] = _masked_element_mean(
                 (torch.diff(pred.joint_dof, dim=1) - torch.diff(gt.joint_dof, dim=1)).pow(2),
                 pair_mask,
             )
@@ -216,11 +225,11 @@ class MotionLoss(nn.Module):
         pred_fk_local = None
         if needs_fk:
             pred_qpos, pred_fk, pred_fk_local = self._decode_fk(pred, batch, representation, valid)
-            terms["body_pos_consistency_loss"] = _masked_sum_batch_mean(
+            terms["body_pos_consistency_loss"] = _masked_element_mean(
                 (pred.body_link_pos_local - pred_fk_local.body_link_pos_local).pow(2),
                 valid[:, :, None],
             )
-            terms["fk_body_pos_loss"] = _masked_sum_batch_mean(
+            terms["fk_body_pos_loss"] = _masked_element_mean(
                 (pred_fk_local.body_link_pos_local - gt.body_link_pos_local).pow(2),
                 valid[:, :, None],
             )
@@ -234,14 +243,14 @@ class MotionLoss(nn.Module):
                     pred_fk["body_quat_w"],
                     batch["canon_root_quat"].to(pred_features.device),
                 )
-                terms["fk_body_rot_loss"] = _masked_sum_batch_mean(
+                terms["fk_body_rot_loss"] = _masked_element_mean(
                     _rotation_geodesic_sq(pred_body_rot_local, gt_body_rot_local),
                     valid[:, :, None],
                 )
 
             if pred_features.shape[1] > 1:
                 pair_mask = valid[:, 1:] & valid[:, :-1]
-                terms["body_vel_loss"] = _masked_sum_batch_mean(
+                terms["body_vel_loss"] = _masked_element_mean(
                     (torch.diff(pred_fk_local.body_link_pos_local, dim=1) - torch.diff(gt.body_link_pos_local, dim=1)).pow(2),
                     pair_mask[:, :, None],
                 )
@@ -251,7 +260,7 @@ class MotionLoss(nn.Module):
                 pred_fk["body_quat_w"],
             )
             sole_bottom = sole_points[..., 2] - sole_radii.view(1, 1, -1)
-            terms["terrain_penetration_loss"] = _masked_sum_batch_mean(torch.relu(-sole_bottom).pow(2), valid[:, :, None])
+            terms["terrain_penetration_loss"] = _masked_element_mean(torch.relu(-sole_bottom).pow(2), valid[:, :, None])
             if "body_pos_w" in batch and "body_quat_w" in batch:
                 gt_sole, gt_radii = representation.kinematics.get_sole_proxy_points(
                     batch["body_pos_w"].to(pred_features.device),
@@ -266,10 +275,10 @@ class MotionLoss(nn.Module):
                     & (gt_bottom <= self.contact_height_threshold)
                     & (gt_vel.norm(dim=-1) <= self.contact_velocity_threshold)
                 )
-                terms["contact_height_loss"] = _masked_sum_batch_mean(sole_bottom.pow(2), contact_mask)
+                terms["contact_height_loss"] = _masked_element_mean(sole_bottom.pow(2), contact_mask)
                 if pred_features.shape[1] > 1:
                     pred_vel = torch.diff(sole_points[..., :2], dim=1) * fps.view(-1, 1, 1, 1)
-                    terms["contact_velocity_loss"] = _masked_sum_batch_mean(
+                    terms["contact_velocity_loss"] = _masked_element_mean(
                         pred_vel.pow(2).sum(dim=-1),
                         contact_mask[:, 1:] & contact_mask[:, :-1],
                     )
@@ -278,19 +287,19 @@ class MotionLoss(nn.Module):
         if history is not None:
             prev = representation.codec.split_features(history.to(pred_features.device)[:, -1])
             first_valid = valid[:, :1]
-            terms["seam_root_pos_loss"] = _masked_sum_batch_mean(
+            terms["seam_root_pos_loss"] = _masked_element_mean(
                 (pred.root_pos_local[:, :1] - prev.root_pos_local[:, None]).pow(2),
                 first_valid,
             )
-            terms["seam_root_rot_loss"] = _masked_sum_batch_mean(
+            terms["seam_root_rot_loss"] = _masked_element_mean(
                 _quat_geodesic_sq(pred.root_rot_local_quat[:, :1], prev.root_rot_local_quat[:, None]),
                 first_valid,
             )
-            terms["seam_joint_dof_loss"] = _masked_sum_batch_mean(
+            terms["seam_joint_dof_loss"] = _masked_element_mean(
                 (pred.joint_dof[:, :1] - prev.joint_dof[:, None]).pow(2),
                 first_valid,
             )
-            terms["seam_body_pos_loss"] = _masked_sum_batch_mean(
+            terms["seam_body_pos_loss"] = _masked_element_mean(
                 (pred.body_link_pos_local[:, :1] - prev.body_link_pos_local[:, None]).pow(2),
                 first_valid[:, :, None],
             )

--- a/src/omg/generation/losses/motion.py
+++ b/src/omg/generation/losses/motion.py
@@ -10,7 +10,6 @@ from omg.generation.metrics import physical_motion_metrics
 from omg.utils.rotation_conversions import (
     quaternion_invert,
     quaternion_multiply,
-    quaternion_to_axis_angle,
     quaternion_to_matrix,
 )
 
@@ -36,29 +35,22 @@ def _masked_element_mean(value: torch.Tensor, mask: torch.Tensor) -> torch.Tenso
     return per_sample[has_values].mean()
 
 
-
-def _quat_geodesic_sq(pred: torch.Tensor, target: torch.Tensor) -> torch.Tensor:
+def _quat_chordal_sq(pred: torch.Tensor, target: torch.Tensor) -> torch.Tensor:
     pred = F.normalize(pred, dim=-1)
     target = F.normalize(target, dim=-1)
     pred_matrix = quaternion_to_matrix(pred)
     target_matrix = quaternion_to_matrix(target)
-    return _rotation_geodesic_sq(pred_matrix, target_matrix)
+    return _rotation_chordal_sq(pred_matrix, target_matrix)
 
 
-def _rotation_geodesic_sq(pred: torch.Tensor, target: torch.Tensor) -> torch.Tensor:
-    relative = pred.transpose(-1, -2) @ target
-    trace = relative.diagonal(offset=0, dim1=-2, dim2=-1).sum(dim=-1)
-    cos = ((trace - 1.0) * 0.5).clamp(-1.0 + 1e-6, 1.0 - 1e-6)
-    return torch.acos(cos).pow(2)
+def _rotation_chordal_sq(pred: torch.Tensor, target: torch.Tensor) -> torch.Tensor:
+    """Smooth SO(3) distance with the same local quadratic as angle squared."""
+    return 0.5 * (pred - target).square().sum(dim=(-2, -1))
 
 
-def _quat_velocity(quat: torch.Tensor, fps: torch.Tensor) -> torch.Tensor:
+def _quat_relative_rotation(quat: torch.Tensor) -> torch.Tensor:
     delta = quaternion_multiply(quat[:, 1:], quaternion_invert(quat[:, :-1]))
-    axis_angle = quaternion_to_axis_angle(delta)
-    while fps.ndim < axis_angle.ndim:
-        fps = fps.unsqueeze(-1)
-    return axis_angle * fps
-
+    return quaternion_to_matrix(F.normalize(delta, dim=-1))
 
 
 class MotionLoss(nn.Module):
@@ -174,7 +166,7 @@ class MotionLoss(nn.Module):
         zero = pred_features.new_zeros(())
         terms = {
             "simple_root_pos_loss": _masked_element_mean((pred.root_pos_local - gt.root_pos_local).pow(2), valid),
-            "simple_root_rot_loss": _masked_element_mean(_quat_geodesic_sq(pred.root_rot_local_quat, gt.root_rot_local_quat), valid),
+            "simple_root_rot_loss": _masked_element_mean(_quat_chordal_sq(pred.root_rot_local_quat, gt.root_rot_local_quat), valid),
             "simple_joint_dof_loss": _masked_element_mean((pred.joint_dof - gt.joint_dof).pow(2), valid),
             "simple_body_pos_loss": _masked_element_mean((pred.body_link_pos_local - gt.body_link_pos_local).pow(2), valid[:, :, None]),
             "body_pos_consistency_loss": zero,
@@ -199,10 +191,10 @@ class MotionLoss(nn.Module):
                 (torch.diff(pred.root_pos_local, dim=1) - torch.diff(gt.root_pos_local, dim=1)).pow(2),
                 pair_mask,
             )
-            terms["vel_root_rot_loss"] = _masked_element_mean(
-                (_quat_velocity(pred.root_rot_local_quat, fps) - _quat_velocity(gt.root_rot_local_quat, fps)).pow(2),
-                pair_mask,
-            )
+            pred_delta = _quat_relative_rotation(pred.root_rot_local_quat)
+            gt_delta = _quat_relative_rotation(gt.root_rot_local_quat)
+            angular_rate_sq = _rotation_chordal_sq(pred_delta, gt_delta) * fps[:, None].square() / 3.0
+            terms["vel_root_rot_loss"] = _masked_element_mean(angular_rate_sq, pair_mask)
             terms["vel_joint_dof_loss"] = _masked_element_mean(
                 (torch.diff(pred.joint_dof, dim=1) - torch.diff(gt.joint_dof, dim=1)).pow(2),
                 pair_mask,
@@ -244,7 +236,7 @@ class MotionLoss(nn.Module):
                     batch["canon_root_quat"].to(pred_features.device),
                 )
                 terms["fk_body_rot_loss"] = _masked_element_mean(
-                    _rotation_geodesic_sq(pred_body_rot_local, gt_body_rot_local),
+                    _rotation_chordal_sq(pred_body_rot_local, gt_body_rot_local),
                     valid[:, :, None],
                 )
 
@@ -292,7 +284,7 @@ class MotionLoss(nn.Module):
                 first_valid,
             )
             terms["seam_root_rot_loss"] = _masked_element_mean(
-                _quat_geodesic_sq(pred.root_rot_local_quat[:, :1], prev.root_rot_local_quat[:, None]),
+                _quat_chordal_sq(pred.root_rot_local_quat[:, :1], prev.root_rot_local_quat[:, None]),
                 first_valid,
             )
             terms["seam_joint_dof_loss"] = _masked_element_mean(

--- a/src/omg/motion/feature_codec.py
+++ b/src/omg/motion/feature_codec.py
@@ -15,6 +15,7 @@ from omg.utils.rotation_conversions import (
     quaternion_multiply,
     quaternion_to_matrix,
     rotation_6d_to_matrix,
+    rotation_6d_to_matrix_canonical_gradient,
     standardize_quaternion,
 )
 
@@ -34,6 +35,7 @@ class G1MotionFeatureCodec:
         num_prev_states: int = 2,
         canonical_frame_idx: int | None = None,
         rotation_representation: str = "quat",
+        rot6d_gradient_mode: str = "vanilla",
     ):
         self.kinematics = kinematics
         self.num_prev_states = int(num_prev_states)
@@ -46,6 +48,7 @@ class G1MotionFeatureCodec:
             )
         self.num_body_links = self.kinematics.num_bodies - 1
         self.rotation_representation = self._normalize_rotation_representation(rotation_representation)
+        self.rot6d_gradient_mode = self._normalize_rot6d_gradient_mode(rot6d_gradient_mode)
         self.root_rot_dim = {"quat": 4, "rot6d": 6}[self.rotation_representation]
         self.feature_dim = 3 + self.root_rot_dim + self.kinematics.num_joints + self.num_body_links * 3
         joint_start = 3 + self.root_rot_dim
@@ -73,6 +76,23 @@ class G1MotionFeatureCodec:
         }
         if key not in aliases:
             raise ValueError(f"Unsupported rotation_representation={value!r}; expected quat or rot6d")
+        return aliases[key]
+
+    @staticmethod
+    def _normalize_rot6d_gradient_mode(value: str) -> str:
+        key = str(value).strip().lower().replace("-", "_")
+        aliases = {
+            "vanilla": "vanilla",
+            "autograd": "vanilla",
+            "gram_schmidt": "vanilla",
+            "canonical": "canonical",
+            "canonical_gradient": "canonical",
+            "canonical_section": "canonical",
+        }
+        if key not in aliases:
+            raise ValueError(
+                f"Unsupported rot6d_gradient_mode={value!r}; expected vanilla or canonical"
+            )
         return aliases[key]
 
     def _standardize_quat(self, quat: torch.Tensor) -> torch.Tensor:
@@ -117,7 +137,11 @@ class G1MotionFeatureCodec:
         if self.rotation_representation == "quat":
             return self._standardize_quat(features)
         if self.rotation_representation == "rot6d":
-            return self._standardize_quat(matrix_to_quaternion(rotation_6d_to_matrix(features)))
+            if self.rot6d_gradient_mode == "canonical":
+                rotation = rotation_6d_to_matrix_canonical_gradient(features)
+            else:
+                rotation = rotation_6d_to_matrix(features)
+            return self._standardize_quat(matrix_to_quaternion(rotation))
         raise AssertionError(f"Unhandled rotation_representation={self.rotation_representation}")
 
     def assemble_features(self, components: MotionComponents) -> torch.Tensor:

--- a/src/omg/motion/representation.py
+++ b/src/omg/motion/representation.py
@@ -30,6 +30,7 @@ class G1MotionRepresentation(nn.Module):
         sequence_length: int = 64,
         clip_std_min: float = 1e-6,
         rotation_representation: str = "quat",
+        rot6d_gradient_mode: str = "vanilla",
     ):
         super().__init__()
         self.feat_dim = feat_dim
@@ -40,9 +41,11 @@ class G1MotionRepresentation(nn.Module):
             num_prev_states=num_prev_states,
             canonical_frame_idx=canonical_frame_idx,
             rotation_representation=rotation_representation,
+            rot6d_gradient_mode=rot6d_gradient_mode,
         )
         self.num_prev_states = num_prev_states
         self.rotation_representation = self.codec.rotation_representation
+        self.rot6d_gradient_mode = self.codec.rot6d_gradient_mode
         self.canonical_frame_idx = self.codec.canonical_frame_idx
         self.sequence_length = int(sequence_length)
         self.is_motion_representation = True

--- a/src/omg/utils/rotation_conversions.py
+++ b/src/omg/utils/rotation_conversions.py
@@ -528,6 +528,70 @@ def rotation_6d_to_matrix(d6: torch.Tensor) -> torch.Tensor:
     return torch.stack((b1, b2, b3), dim=-2)
 
 
+class _Rotation6DToMatrixCanonicalGradient(torch.autograd.Function):
+    """Evaluate the 6D pullback at the canonical inverse image of SO(3)."""
+
+    @staticmethod
+    def forward(ctx, d6: torch.Tensor) -> torch.Tensor:
+        rotation = rotation_6d_to_matrix(d6)
+        ctx.save_for_backward(rotation)
+        ctx.input_dtype = d6.dtype
+        return rotation
+
+    @staticmethod
+    def backward(ctx, grad_rotation: torch.Tensor):
+        (rotation,) = ctx.saved_tensors
+        work_dtype = (
+            torch.float32
+            if ctx.input_dtype in (torch.float16, torch.bfloat16)
+            else ctx.input_dtype
+        )
+        # Every non-degenerate 6D vector in the same Gram--Schmidt inverse
+        # image denotes the same rotation.  Pulling the gradient back at the
+        # canonical first-two-row representative removes raw scale and
+        # collinearity from the Jacobian while retaining a linear VJP.
+        rotation_work = rotation.to(dtype=work_dtype)
+        grad_work = grad_rotation.to(dtype=work_dtype)
+        first = rotation_work[..., 0, :]
+        second = rotation_work[..., 1, :]
+        grad_first = grad_work[..., 0, :] + torch.cross(
+            second, grad_work[..., 2, :], dim=-1
+        )
+        grad_second = grad_work[..., 1, :] + torch.cross(
+            grad_work[..., 2, :], first, dim=-1
+        )
+
+        # Exact Gram--Schmidt VJP at two orthonormal input rows.  Writing it
+        # explicitly avoids opening a nested autograd graph in every backward.
+        grad_second_projected = grad_second - (
+            grad_second * second
+        ).sum(dim=-1, keepdim=True) * second
+        first_coupling = (
+            grad_second_projected * first
+        ).sum(dim=-1, keepdim=True)
+        input_second_grad = grad_second_projected - first_coupling * first
+        first_total = grad_first - first_coupling * second
+        input_first_grad = first_total - (
+            first_total * first
+        ).sum(dim=-1, keepdim=True) * first
+        gradient = torch.cat((input_first_grad, input_second_grad), dim=-1)
+        return gradient.to(dtype=ctx.input_dtype)
+
+
+def rotation_6d_to_matrix_canonical_gradient(d6: torch.Tensor) -> torch.Tensor:
+    """Use a well-conditioned canonical-section VJP for the Zhou 6D map.
+
+    The forward projection is unchanged.  In backward, the exact
+    Gram--Schmidt VJP is evaluated at the canonical orthonormal member of the
+    input's inverse image.  This keeps the pullback bounded near degenerate raw
+    6D vectors and, unlike a finite projective goal step, remains linear in the
+    upstream gradient so ordinary loss weights and reductions are preserved.
+    """
+    if d6.shape[-1] != 6:
+        raise ValueError(f"Expected 6D rotation input, got shape {tuple(d6.shape)}")
+    return _Rotation6DToMatrixCanonicalGradient.apply(d6)
+
+
 def matrix_to_rotation_6d(matrix: torch.Tensor) -> torch.Tensor:
     """
     Converts rotation matrices to 6D rotation representation by Zhou et al. [1]

--- a/tests/generation/test_motion_loss_reduction.py
+++ b/tests/generation/test_motion_loss_reduction.py
@@ -1,0 +1,29 @@
+import torch
+
+from omg.generation.losses.motion import _masked_element_mean
+
+
+def test_masked_element_mean_counts_trailing_event_dimensions():
+    values = torch.tensor(
+        [
+            [[1.0, 3.0, 5.0], [100.0, 100.0, 100.0]],
+            [[2.0, 4.0, 6.0], [8.0, 10.0, 12.0]],
+        ]
+    )
+    valid = torch.tensor([[True, False], [True, True]])
+
+    actual = _masked_element_mean(values, valid)
+
+    # Each sample is reduced over all of its valid scalar elements first, so
+    # sequence length does not change that sample's weight in the batch.
+    expected = torch.tensor(((1.0 + 3.0 + 5.0) / 3.0 + (2.0 + 4.0 + 6.0 + 8.0 + 10.0 + 12.0) / 6.0) / 2.0)
+    torch.testing.assert_close(actual, expected)
+
+
+def test_masked_element_mean_excludes_samples_without_valid_values():
+    values = torch.tensor([[[100.0, 100.0]], [[2.0, 4.0]]])
+    valid = torch.tensor([[False], [True]])
+
+    actual = _masked_element_mean(values, valid)
+
+    torch.testing.assert_close(actual, torch.tensor(3.0))

--- a/tests/generation/test_motion_loss_reduction.py
+++ b/tests/generation/test_motion_loss_reduction.py
@@ -1,6 +1,7 @@
 import torch
 
-from omg.generation.losses.motion import _masked_element_mean
+from omg.generation.losses.motion import _masked_element_mean, _rotation_chordal_sq
+from omg.utils.rotation_conversions import axis_angle_to_matrix
 
 
 def test_masked_element_mean_counts_trailing_event_dimensions():
@@ -27,3 +28,23 @@ def test_masked_element_mean_excludes_samples_without_valid_values():
     actual = _masked_element_mean(values, valid)
 
     torch.testing.assert_close(actual, torch.tensor(3.0))
+
+
+def test_rotation_chordal_loss_is_locally_angle_squared():
+    angle = torch.tensor([[1.0e-3, -2.0e-3, 3.0e-3]])
+    pred = axis_angle_to_matrix(angle)
+    target = torch.eye(3).unsqueeze(0)
+
+    actual = _rotation_chordal_sq(pred, target)
+
+    torch.testing.assert_close(actual, angle.square().sum(dim=-1), atol=1e-8, rtol=1e-5)
+
+
+def test_rotation_chordal_gradient_is_finite_at_pi_cut_locus():
+    angle = torch.tensor([[torch.pi, 0.0, 0.0]], requires_grad=True)
+    pred = axis_angle_to_matrix(angle)
+    target = torch.eye(3).unsqueeze(0)
+
+    _rotation_chordal_sq(pred, target).sum().backward()
+
+    assert torch.isfinite(angle.grad).all()

--- a/tests/generation/test_qk_normalized_attention.py
+++ b/tests/generation/test_qk_normalized_attention.py
@@ -1,0 +1,44 @@
+import torch
+
+from omg.generation.denoisers.transformer import (
+    MotionTransformerBlock,
+    _qk_normalized_cross_attention,
+)
+
+
+def _attention_output(block: MotionTransformerBlock, query: torch.Tensor, context: torch.Tensor) -> torch.Tensor:
+    mask = torch.zeros(query.shape[0], context.shape[1], dtype=torch.bool)
+    return _qk_normalized_cross_attention(block.cross_attn, query, context, mask)
+
+
+def test_qk_normalized_cross_attention_is_invariant_to_projection_scale():
+    torch.manual_seed(7)
+    block = MotionTransformerBlock(hidden_dim=32, num_heads=4, dropout=0.0).eval()
+    query = torch.randn(2, 5, 32)
+    context = torch.randn(2, 3, 32)
+    expected = _attention_output(block, query, context)
+
+    with torch.no_grad():
+        block.cross_attn.in_proj_weight[:64].mul_(11.0)
+        block.cross_attn.in_proj_bias[:64].mul_(11.0)
+    actual = _attention_output(block, query, context)
+
+    torch.testing.assert_close(actual, expected, atol=2e-6, rtol=2e-6)
+
+
+def test_qk_normalized_cross_attention_input_gradient_is_scale_invariant():
+    torch.manual_seed(11)
+    block = MotionTransformerBlock(hidden_dim=32, num_heads=4, dropout=0.0).eval()
+    context = torch.randn(2, 3, 32)
+    query = torch.randn(2, 5, 32, requires_grad=True)
+    _attention_output(block, query, context).square().mean().backward()
+    expected = query.grad.clone()
+
+    block.zero_grad(set_to_none=True)
+    with torch.no_grad():
+        block.cross_attn.in_proj_weight[:64].mul_(17.0)
+        block.cross_attn.in_proj_bias[:64].mul_(17.0)
+    scaled_query = query.detach().clone().requires_grad_(True)
+    _attention_output(block, scaled_query, context).square().mean().backward()
+
+    torch.testing.assert_close(scaled_query.grad, expected, atol=2e-7, rtol=2e-5)

--- a/tests/generation/test_rotation_representation.py
+++ b/tests/generation/test_rotation_representation.py
@@ -2,7 +2,12 @@ import torch
 
 from omg.motion.feature_codec import G1MotionFeatureCodec
 from omg.robots.g1.kinematics import G1Kinematics
-from omg.utils.rotation_conversions import axis_angle_to_quaternion
+from omg.utils.rotation_conversions import (
+    axis_angle_to_matrix,
+    axis_angle_to_quaternion,
+    rotation_6d_to_matrix,
+    rotation_6d_to_matrix_canonical_gradient,
+)
 
 
 def _codec(rotation_representation: str) -> G1MotionFeatureCodec:
@@ -37,3 +42,30 @@ def test_root_rotation_representation_roundtrip_to_quaternion():
         recovered = codec.rotation_features_to_quat(features)
         alignment = (quat * recovered).sum(dim=-1).abs()
         assert torch.allclose(alignment, torch.ones_like(alignment), atol=1e-5)
+
+
+def test_canonical_gradient_matches_vanilla_at_canonical_representative():
+    axis_angle = torch.tensor([[0.2, -0.1, 0.3]])
+    canonical = axis_angle_to_matrix(axis_angle)[..., :2, :].reshape(1, 6)
+    upstream = torch.randn(1, 3, 3)
+
+    vanilla = canonical.clone().requires_grad_(True)
+    (rotation_6d_to_matrix(vanilla) * upstream).sum().backward()
+    canonical_mode = canonical.clone().requires_grad_(True)
+    (rotation_6d_to_matrix_canonical_gradient(canonical_mode) * upstream).sum().backward()
+
+    torch.testing.assert_close(canonical_mode.grad, vanilla.grad, atol=1e-6, rtol=1e-6)
+
+
+def test_canonical_gradient_is_bounded_and_linear_at_degenerate_input():
+    candidate = torch.tensor([[1.0e-7, 0.0, 0.0, 1.0e-7, 1.0e-9, 0.0]])
+    upstream = torch.randn(1, 3, 3)
+
+    first = candidate.clone().requires_grad_(True)
+    (rotation_6d_to_matrix_canonical_gradient(first) * upstream).sum().backward()
+    scaled = candidate.clone().requires_grad_(True)
+    (0.3 * rotation_6d_to_matrix_canonical_gradient(scaled) * upstream).sum().backward()
+
+    assert torch.isfinite(first.grad).all()
+    assert first.grad.norm() < 10.0
+    torch.testing.assert_close(scaled.grad, 0.3 * first.grad, atol=1e-6, rtol=1e-6)


### PR DESCRIPTION
## What changed

- reduce every motion-loss term over all valid scalar elements, matching the diffusion feature mean
- use a smooth chordal SO(3) objective and a bounded canonical-section VJP for the Zhou 6D representation
- normalize cross-attention queries and keys per head so their radial scale cannot sharpen logits or amplify the input Jacobian
- keep the TensorRT/ONNX attention path mathematically identical
- add regression tests for reduction, SO(3) cut-locus gradients, canonical 6D gradients, Q/K scale invariance, and export parity

## Root cause

The failure had three stacked causes. First, motion losses divided only by valid frames and implicitly summed their trailing xyz/joint/body dimensions. Second, the raw Gram-Schmidt pullback and geodesic `acos` loss introduced singular rotation gradients. After those were removed, exact VJP and layerwise diagnostics exposed the remaining model-wide instability: cross-attention layer 3 query/key norms grew from 29.6/28.2 at step 10k to 47.2/49.2 at step 13.5k while value norms stayed near 20. The unbounded Q/K radial degree of freedom amplified the backward Jacobian through the early Transformer blocks.

Per-head QK normalization removes that radial degree of freedom without clipping gradients, changing loss weights, lowering the learning rate, or adding a threshold-based fallback.

## Validation

- local full suite: `143 passed, 4 skipped`
- A100-4-2 generation/callback suite: `91 passed, 3 skipped`
- same step-13500 checkpoint and batch: total raw gradient `5.77 -> 2.01`
- same A/B, layer 0/1/2 gradients: `3.81/2.55/2.31 -> 0.88/0.57/0.49`
- four-GPU replay step 13500 to 15000 completed in 699.0 s (`2.146 step/s`)
- replay gradient median `0.315`, p95 `0.511`, max `2.012`
- step-15000 loss `0.0688` (`diffusion=0.0383`, `motion=0.0306`)
- crossed the prior failures at steps 11609, 11623, 13608, 13613, and 13690
