### PR TITLE
Normalize rotary self-attention queries and keys

### DIFF
--- a/src/omg/generation/denoisers/transformer.py
+++ b/src/omg/generation/denoisers/transformer.py
@@ -86,6 +86,10 @@ class RotarySelfAttention(nn.Module):
         v = v.transpose(1, 2)
         q, k = self.rope.apply(q, k)
 
+        head_scale = math.sqrt(self.head_dim)
+        q = F.normalize(q.float(), dim=-1).to(dtype=q.dtype) * head_scale
+        k = F.normalize(k.float(), dim=-1).to(dtype=k.dtype) * head_scale
+
         attn_mask = None
         if key_padding_mask is not None:
             attn_mask = torch.zeros(

--- a/src/omg/generation/export/onnx.py
+++ b/src/omg/generation/export/onnx.py
@@ -135,6 +135,9 @@ class TensorRTFriendlyRotarySelfAttention(nn.Module):
         sin = self.sin[:, :, :seq_len, :].to(dtype=q.dtype)
         q = (q * cos) + (_rotate_half_export(q) * sin)
         k = (k * cos) + (_rotate_half_export(k) * sin)
+        head_scale = float(self.head_dim) ** 0.5
+        q = F.normalize(q.float(), dim=-1).to(dtype=q.dtype) * head_scale
+        k = F.normalize(k.float(), dim=-1).to(dtype=k.dtype) * head_scale
 
         attn_mask = None
         if key_padding_mask is not None:

--- a/tests/generation/test_qk_normalized_attention.py
+++ b/tests/generation/test_qk_normalized_attention.py
@@ -2,6 +2,7 @@ import torch
 
 from omg.generation.denoisers.transformer import (
     MotionTransformerBlock,
+    RotarySelfAttention,
     _qk_normalized_cross_attention,
 )
 
@@ -42,3 +43,34 @@ def test_qk_normalized_cross_attention_input_gradient_is_scale_invariant():
     _attention_output(block, scaled_query, context).square().mean().backward()
 
     torch.testing.assert_close(scaled_query.grad, expected, atol=2e-7, rtol=2e-5)
+
+
+def test_qk_normalized_rotary_self_attention_is_invariant_to_projection_scale():
+    torch.manual_seed(13)
+    attention = RotarySelfAttention(hidden_dim=32, num_heads=4, dropout=0.0).eval()
+    inputs = torch.randn(2, 5, 32)
+    expected = attention(inputs)
+
+    with torch.no_grad():
+        attention.qkv.weight[:64].mul_(19.0)
+        attention.qkv.bias[:64].mul_(19.0)
+    actual = attention(inputs)
+
+    torch.testing.assert_close(actual, expected, atol=2e-6, rtol=2e-6)
+
+
+def test_qk_normalized_rotary_self_attention_input_gradient_is_scale_invariant():
+    torch.manual_seed(17)
+    attention = RotarySelfAttention(hidden_dim=32, num_heads=4, dropout=0.0).eval()
+    inputs = torch.randn(2, 5, 32, requires_grad=True)
+    attention(inputs).square().mean().backward()
+    expected = inputs.grad.clone()
+
+    attention.zero_grad(set_to_none=True)
+    with torch.no_grad():
+        attention.qkv.weight[:64].mul_(23.0)
+        attention.qkv.bias[:64].mul_(23.0)
+    scaled_inputs = inputs.detach().clone().requires_grad_(True)
+    attention(scaled_inputs).square().mean().backward()
+
+    torch.testing.assert_close(scaled_inputs.grad, expected, atol=2e-7, rtol=2e-5)


### PR DESCRIPTION
## Summary

- normalize per-head rotary self-attention queries and keys before scaled dot-product attention
- apply the same semantics in the TensorRT-friendly ONNX export path
- add forward and input-gradient invariance tests under positive Q/K projection rescaling

## Root cause

The previous stability fix normalized Q/K only in cross-attention. Rotary self-attention retained an unidentifiable radial degree of freedom, allowing the layer 7/8 Q/K projection norms to grow while V remained stable. In the failed 100M run, layer 8 Q/K/V norms evolved from 18.79/18.67/17.15 at step 20k to 57.35/51.08/20.25 at step 54k before the run diverged at step 55,895.

## Validation

- local full suite: `145 passed, 4 skipped`
- A100 targeted suite: `17 passed`
- same-checkpoint, same-batch, same-noise 54k replay:
  - baseline global-gradient median/P95/max: `0.725 / 1.969 / 4.345`
  - normalized self-attention: `0.171 / 0.234 / 0.567`
  - baseline median total loss: `0.1405`
  - normalized self-attention median total loss: `0.0731`

## Training gate

A new four-GPU, no-gradient-clipping clean run has started from step 0. Keep this PR in Draft until it crosses the prior long-horizon failure region and preserves bounded self-attention Q/K behavior.
