### PR TITLE
Optimize text benchmark sampling

### DIFF
--- a/src/omg/benchmarks/runners/text.py
+++ b/src/omg/benchmarks/runners/text.py
@@ -84,38 +84,59 @@ def _select_sample_records(
     if require_min_two and num_samples < 2:
         raise ValueError("--num-texts must be at least 2 for FID/KID/diversity")
     names = list(datasets.keys())
-    candidates: list[tuple[str, int, int]] = []
+    candidate_spans: list[tuple[str, int, int, int]] = []
     global_index = 0
     per_dataset_counts = {}
-    print("[INFO] Scanning datasets for caption-bearing samples…")
+    print("[INFO] Indexing caption-bearing samples…")
     for name in names:
         dataset = datasets[name]
         count = 0
-        for index in tqdm(
-            range(len(dataset)),
-            desc=f"Captions {name}",
-            unit="idx",
-            leave=False,
-        ):
-            if _has_caption(dataset, index):
-                candidates.append((name, index, global_index))
-                count += 1
-            global_index += 1
+        captions = getattr(dataset, "captions", None)
+        window_offsets = getattr(dataset, "window_offsets", None)
+        if captions is not None and window_offsets is not None and len(window_offsets) == len(captions) + 1:
+            for episode_index, caption in enumerate(captions):
+                if not str(caption).strip():
+                    continue
+                start = int(window_offsets[episode_index])
+                end = min(int(window_offsets[episode_index + 1]), len(dataset))
+                if end <= start:
+                    continue
+                span_count = end - start
+                candidate_spans.append((name, start, global_index + start, span_count))
+                count += span_count
+        else:
+            for index in tqdm(
+                range(len(dataset)),
+                desc=f"Captions {name}",
+                unit="idx",
+                leave=False,
+            ):
+                if _has_caption(dataset, index):
+                    candidate_spans.append((name, index, global_index + index, 1))
+                    count += 1
+        global_index += len(dataset)
         per_dataset_counts[name] = count
-    if not candidates:
+    if not candidate_spans:
         raise ValueError("No caption-bearing samples found in selected datasets")
-    if int(num_samples) > len(candidates):
+    candidate_count = sum(span[3] for span in candidate_spans)
+    if int(num_samples) > candidate_count:
         print(
-            f"[WARN] Requested {num_samples} texts but only found {len(candidates)} caption-bearing samples; "
+            f"[WARN] Requested {num_samples} texts but only found {candidate_count} caption-bearing samples; "
             "evaluating all available samples."
         )
-        num_samples = len(candidates)
+        num_samples = candidate_count
     rng = np.random.default_rng(int(seed))
-    selected = np.sort(rng.choice(len(candidates), size=int(num_samples), replace=False))
+    selected = np.sort(rng.choice(candidate_count, size=int(num_samples), replace=False))
+    span_ends = np.cumsum(np.asarray([span[3] for span in candidate_spans], dtype=np.int64))
+    selected_spans = np.searchsorted(span_ends, selected, side="right")
     records: list[SampleRecord] = []
     selected_counts: dict[str, int] = {}
-    for candidate_index in selected:
-        dataset_name, index, candidate_global = candidates[int(candidate_index)]
+    for candidate_index, span_index in zip(selected, selected_spans, strict=True):
+        dataset_name, span_start, span_global_start, _ = candidate_spans[int(span_index)]
+        previous_end = 0 if int(span_index) == 0 else int(span_ends[int(span_index) - 1])
+        offset = int(candidate_index) - previous_end
+        index = span_start + offset
+        candidate_global = span_global_start + offset
         selected_counts[dataset_name] = selected_counts.get(dataset_name, 0) + 1
         records.append(SampleRecord(dataset=dataset_name, index=index, global_index=candidate_global))
     print(f"[INFO] caption-bearing samples by dataset: {per_dataset_counts}")

--- a/tests/generation/test_benchmark.py
+++ b/tests/generation/test_benchmark.py
@@ -38,6 +38,24 @@ class DummyDataset:
         return {"caption": f"{self.prefix}-{index}", "meta": {"index": index}}
 
 
+class DummyEpisodeWindowDataset:
+    def __init__(self, captions: list[str], window_counts: list[int]):
+        assert len(captions) == len(window_counts)
+        self.captions = captions
+        self.window_offsets = np.concatenate(
+            [np.zeros(1, dtype=np.int64), np.cumsum(window_counts, dtype=np.int64)]
+        )
+        self.getitem_calls = 0
+
+    def __len__(self):
+        return int(self.window_offsets[-1])
+
+    def __getitem__(self, index: int):
+        self.getitem_calls += 1
+        episode = int(np.searchsorted(self.window_offsets, index, side="right") - 1)
+        return {"caption": self.captions[episode], "meta": {"index": index}}
+
+
 class DummyConditionDataset:
     def __init__(self, masks):
         self.masks = masks
@@ -113,6 +131,28 @@ def test_select_sample_records_clamps_to_available_caption_samples():
     records = _select_sample_records(datasets, num_samples=3, seed=0)
     assert len(records) == 2
     assert {(record.dataset, record.index) for record in records} == {("a", 0), ("a", 1)}
+
+
+def test_select_sample_records_uses_exact_episode_window_spans():
+    datasets = {
+        "a": DummyEpisodeWindowDataset(["walk", "", "turn"], [2, 3, 1]),
+        "b": DummyEpisodeWindowDataset(["jump", "sit"], [2, 2]),
+    }
+    exhaustive_candidates = [
+        SampleRecord(dataset="a", index=0, global_index=0),
+        SampleRecord(dataset="a", index=1, global_index=1),
+        SampleRecord(dataset="a", index=5, global_index=5),
+        SampleRecord(dataset="b", index=0, global_index=6),
+        SampleRecord(dataset="b", index=1, global_index=7),
+        SampleRecord(dataset="b", index=2, global_index=8),
+        SampleRecord(dataset="b", index=3, global_index=9),
+    ]
+    selected = np.sort(np.random.default_rng(17).choice(len(exhaustive_candidates), size=5, replace=False))
+
+    records = _select_sample_records(datasets, num_samples=5, seed=17)
+
+    assert records == [exhaustive_candidates[int(index)] for index in selected]
+    assert all(dataset.getitem_calls == 0 for dataset in datasets.values())
 
 
 def test_sample_records_round_trip(tmp_path):


### PR DESCRIPTION
## Summary

- index caption-bearing materialized windows from episode-level `captions` and `window_offsets`
- sample uniformly over the exact window population without materializing every candidate
- retain the existing per-window scan for datasets that do not expose episode spans
- add a regression test proving identical seeded selection to exhaustive window enumeration

## Motivation

The text benchmark previously called `dataset[index]` for every window to find non-empty captions. On the official materialized validation/test datasets this means millions of expensive dataset reads before generating the requested 1,024 samples.

Materialized episode datasets already expose each episode caption and its contiguous window interval. Representing these intervals as weighted spans preserves the original uniform-over-windows sampling distribution while reducing candidate construction from a full window scan to episode indexing.

This changes benchmark startup cost only. Generation, evaluator inputs, FID/KID/diversity definitions, and seeded sampling semantics are unchanged.

## Validation

- `PYTHONPATH=src python -m pytest -q tests/generation/test_benchmark.py`
- Result on A100-4-2 CUDA environment: `12 passed`
- `git diff --check`
