### PR TITLE
Document released checkpoints and evaluator

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,13 +56,25 @@ task-specific extras.
 
 ## 2. Download Data and Artifacts
 
-OMG-Data is released as an official LeRobotDataset v3 dataset. Model artifacts
-will also be released on Hugging Face:
+OMG-Data is released as an official LeRobotDataset v3 dataset. Pretrained model
+checkpoints and the benchmark evaluator are available from the official
+[THU-MARS/OMG Hugging Face repository](https://huggingface.co/THU-MARS/OMG):
 
 - [OMG-Data](https://huggingface.co/datasets/THU-MARS/OMG-Data)
 - [Materialized OMG-Data]() (coming soon)
-- [OMG checkpoints]() (coming soon)
-- [OMG evaluator]() (coming soon)
+- [OMG checkpoints and evaluator](https://huggingface.co/THU-MARS/OMG/tree/main)
+
+| Model | Training step | Checkpoint |
+| --- | ---: | --- |
+| OMG 50M | 90,000 | [`checkpoints/50m/sstep=090000.ckpt`](https://huggingface.co/THU-MARS/OMG/blob/main/checkpoints/50m/sstep%3D090000.ckpt) |
+| OMG 100M | 100,000 | [`checkpoints/100m/sstep=100000.ckpt`](https://huggingface.co/THU-MARS/OMG/blob/main/checkpoints/100m/sstep%3D100000.ckpt) |
+| OMG 300M | 55,000 | [`checkpoints/300m/sstep=055000.ckpt`](https://huggingface.co/THU-MARS/OMG/blob/main/checkpoints/300m/sstep%3D055000.ckpt) |
+| OMG 500M | 50,000 | [`checkpoints/500m/sstep=050000.ckpt`](https://huggingface.co/THU-MARS/OMG/blob/main/checkpoints/500m/sstep%3D050000.ckpt) |
+
+The pretrained benchmark evaluator is available at
+[`evaluator/step_004000.pt`](https://huggingface.co/THU-MARS/OMG/blob/main/evaluator/step_004000.pt).
+Release checksums are listed in
+[`SHA256SUMS`](https://huggingface.co/THU-MARS/OMG/blob/main/SHA256SUMS).
 
 Text-conditioned training and generation require the Hugging Face `t5-base`
 text encoder. By default, configs load it from `${OMG_MODELS_ROOT}/t5-base-local`.


### PR DESCRIPTION
## Summary

- replace the checkpoint and evaluator `coming soon` placeholders with the official `THU-MARS/OMG` Hugging Face release link
- add a table covering the released 50M, 100M, 300M, and 500M checkpoints and their training steps
- link the released evaluator and `SHA256SUMS` manifest

## Why

The public Hugging Face artifacts are already available, while the repository README still describes the checkpoints and evaluator as unreleased. This update makes the documented release state match the public artifacts and gives users direct, version-specific download paths.

## Validation

- `git diff --check`
- verified every added Hugging Face file link returns HTTP 200
