### PR TITLE
Add Hugging Face badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
   <p>
     <a href="https://arxiv.org/"><img src="https://img.shields.io/badge/arXiv-Paper-b31b1b.svg" alt="arXiv"></a>
     <a href="https://tsinghua-mars-lab.github.io/OMG/"><img src="https://img.shields.io/badge/Website-Page-Green" alt="Website"></a>
+    <a href="https://huggingface.co/THU-MARS/OMG"><img src="https://img.shields.io/badge/%F0%9F%A4%97%20Hugging%20Face-Models%20%26%20Data-FFD21E" alt="Hugging Face"></a>
   </p>
   <p>
     <img src="assets/teaser.png" alt="OMG teaser" width="900">


### PR DESCRIPTION
## What changed

- add a Hugging Face badge below the repository description
- link the badge to the official `THU-MARS/OMG` Hugging Face repository

## Why

The pretrained checkpoints, evaluator, and related release artifacts are hosted on Hugging Face. The badge makes the official artifact page directly discoverable from the README header.

## Validation

- README HTML structure and diff checked
- documentation-only change; no runtime code changed
