### PR TITLE
Add Hugging Face links to project website

### DIFF
--- a/index.html
+++ b/index.html
@@ -99,6 +99,14 @@
               <span class="button-icon button-icon-github" aria-hidden="true"></span>
               <span>Code</span>
             </a>
+            <a class="button button-secondary" href="https://huggingface.co/THU-MARS/OMG" target="_blank" rel="noopener" aria-label="OMG models on Hugging Face">
+              <span class="button-icon-huggingface" aria-hidden="true">🤗</span>
+              <span>Model</span>
+            </a>
+            <a class="button button-secondary" href="https://huggingface.co/datasets/THU-MARS/OMG-Data" target="_blank" rel="noopener" aria-label="OMG-Data on Hugging Face">
+              <span class="button-icon-huggingface" aria-hidden="true">🤗</span>
+              <span>Dataset</span>
+            </a>
             <a class="button button-secondary" href="#citation">
               <span class="button-icon button-icon-cite" aria-hidden="true"></span>
               <span>Cite</span>

--- a/scripts/verify-site.mjs
+++ b/scripts/verify-site.mjs
@@ -22,9 +22,12 @@ const requiredSnippets = [
   ["composition demo poster", "./static/results/composition-realtime-switching-poster.jpg"],
   ["arxiv link", "https://arxiv.org/abs/2606.10340"],
   ["github code link", "https://github.com/Tsinghua-MARS-Lab/OMG"],
+  ["hugging face model link", "https://huggingface.co/THU-MARS/OMG"],
+  ["hugging face dataset link", "https://huggingface.co/datasets/THU-MARS/OMG-Data"],
   ["cite link", 'href="#citation"'],
   ["arxiv icon", "button-icon-arxiv"],
   ["github icon", "button-icon-github"],
+  ["hugging face icon", "button-icon-huggingface"],
   ["cite icon", "button-icon-cite"],
   ["dataset hours", "1174.66"],
   ["model family", "OMG-DiT"]

--- a/static/css/index.css
+++ b/static/css/index.css
@@ -327,6 +327,13 @@ sup {
   -webkit-mask-image: url("../images/omg/icons/cite.svg");
 }
 
+.button-icon-huggingface {
+  display: block;
+  flex: 0 0 auto;
+  font-size: 1rem;
+  line-height: 1;
+}
+
 .button-primary {
   background: var(--ink);
   color: #fffaf4;


### PR DESCRIPTION
## What changed

- add a `Model` button linking to the official `THU-MARS/OMG` Hugging Face repository
- add a `Dataset` button linking to the official `THU-MARS/OMG-Data` dataset
- use the Hugging Face 🤗 icon while preserving the existing project-button styling
- extend the site verifier to require both links and the icon class

## Why

The project website currently links the paper and source code but does not expose the released checkpoints, evaluator, or dataset from the hero section.

## Impact

After this PR is merged into `website`, the existing GitHub Pages workflow will deploy the two new homepage links.

## Validation

- `node scripts/verify-site.mjs`: passed
- both Hugging Face targets return HTTP 200
- `git diff --check`: passed
