### PR TITLE
Validate checkpoint architecture during ONNX export

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,23 @@ PYTHONPATH=src python -m omg.cli.generation.export_onnx \
 
 The exporter writes a metadata sidecar next to the ONNX file. Runtime planners
 use it to recover sequence length, condition dimensions, representation, and
-diffusion settings.
+diffusion settings. New checkpoints record their attention architecture and the
+exporter rejects a mismatched config. For checkpoints created before this
+contract existed, declare the training semantics explicitly; for example, a
+checkpoint trained with cross-attention QK normalization only requires:
+
+```bash
+PYTHONPATH=src python -m omg.cli.generation.export_onnx \
+  --exp 100m_omnimodal \
+  --ckpt_path /path/to/legacy.ckpt \
+  --legacy-attention-contract cross-only \
+  denoiser.self_attention_qk_norm=false \
+  denoiser.cross_attention_qk_norm=true
+```
+
+Export is fail-closed: it numerically compares the training denoiser, the
+TensorRT-compatible wrapper, and the emitted ONNX graph before retaining the
+artifact.
 
 ## 7. Generate and Track
 

--- a/configs/generation/denoiser/transformer.yaml
+++ b/configs/generation/denoiser/transformer.yaml
@@ -10,3 +10,5 @@ rope_base: 10000.0
 audio_local_attn_window: 8
 human_motion_local_attn_window: 2
 use_human_motion_local_attn: false
+self_attention_qk_norm: true
+cross_attention_qk_norm: true

--- a/configs/generation/denoiser/transformer_100m.yaml
+++ b/configs/generation/denoiser/transformer_100m.yaml
@@ -10,3 +10,5 @@ rope_base: 10000.0
 audio_local_attn_window: 8
 human_motion_local_attn_window: 2
 use_human_motion_local_attn: false
+self_attention_qk_norm: true
+cross_attention_qk_norm: true

--- a/configs/generation/denoiser/transformer_1b.yaml
+++ b/configs/generation/denoiser/transformer_1b.yaml
@@ -10,3 +10,5 @@ rope_base: 10000.0
 audio_local_attn_window: 8
 human_motion_local_attn_window: 2
 use_human_motion_local_attn: false
+self_attention_qk_norm: true
+cross_attention_qk_norm: true

--- a/configs/generation/denoiser/transformer_300m.yaml
+++ b/configs/generation/denoiser/transformer_300m.yaml
@@ -10,3 +10,5 @@ rope_base: 10000.0
 audio_local_attn_window: 8
 human_motion_local_attn_window: 2
 use_human_motion_local_attn: false
+self_attention_qk_norm: true
+cross_attention_qk_norm: true

--- a/configs/generation/denoiser/transformer_500m.yaml
+++ b/configs/generation/denoiser/transformer_500m.yaml
@@ -10,3 +10,5 @@ rope_base: 10000.0
 audio_local_attn_window: 8
 human_motion_local_attn_window: 2
 use_human_motion_local_attn: false
+self_attention_qk_norm: true
+cross_attention_qk_norm: true

--- a/configs/generation/denoiser/transformer_50m.yaml
+++ b/configs/generation/denoiser/transformer_50m.yaml
@@ -10,3 +10,5 @@ rope_base: 10000.0
 audio_local_attn_window: 8
 human_motion_local_attn_window: 2
 use_human_motion_local_attn: false
+self_attention_qk_norm: true
+cross_attention_qk_norm: true

--- a/docs/generation.md
+++ b/docs/generation.md
@@ -116,7 +116,24 @@ PYTHONPATH=src python -m omg.cli.generation.export_onnx \
 
 The exporter writes a sidecar metadata file next to the ONNX model. The planner
 uses that metadata to recover sequence length, feature dimension, text/audio
-settings, representation, and diffusion contract.
+settings, representation, diffusion contract, and attention architecture.
+
+New checkpoints carry an architecture contract. Legacy checkpoints do not, and
+QK-normalization changes cannot be inferred from parameter names or shapes. A
+legacy export must therefore declare one of `none`, `cross-only`, `self-only`,
+or `self-and-cross` and instantiate the matching denoiser. Example:
+
+```bash
+PYTHONPATH=src python -m omg.cli.generation.export_onnx \
+  --exp 100m_omnimodal \
+  --ckpt_path /path/to/legacy.ckpt \
+  --legacy-attention-contract cross-only \
+  denoiser.self_attention_qk_norm=false \
+  denoiser.cross_attention_qk_norm=true
+```
+
+The exporter validates training-denoiser-to-wrapper and wrapper-to-ONNX numeric
+parity. It deletes the emitted graph and fails if either gate exceeds tolerance.
 
 ## TensorRT Runtime
 

--- a/src/omg/cli/generation/export_onnx.py
+++ b/src/omg/cli/generation/export_onnx.py
@@ -8,6 +8,10 @@ import torch
 from hydra import compose, initialize_config_dir
 from hydra.utils import instantiate
 
+from omg.generation.architecture import (
+    LEGACY_ATTENTION_CONTRACTS,
+    validate_checkpoint_architecture_contract,
+)
 from omg.generation.export import export_denoiser_step_onnx, metadata_sidecar_path
 
 
@@ -15,9 +19,21 @@ def _config_dir() -> Path:
     return Path(__file__).resolve().parents[4] / "configs" / "generation"
 
 
-def _load_model(cfg, ckpt_path: str | Path, device: torch.device, *, strict: bool):
+def _load_model(
+    cfg,
+    ckpt_path: str | Path,
+    device: torch.device,
+    *,
+    strict: bool,
+    legacy_attention_contract: str | None,
+):
     model = instantiate(cfg.model)
     payload = torch.load(ckpt_path, map_location="cpu")
+    architecture = validate_checkpoint_architecture_contract(
+        payload,
+        model,
+        legacy_attention_contract=legacy_attention_contract,
+    )
     state_dict = payload.get("state_dict", payload)
     incompatible = model.load_state_dict(state_dict, strict=bool(strict))
     if not strict:
@@ -25,6 +41,7 @@ def _load_model(cfg, ckpt_path: str | Path, device: torch.device, *, strict: boo
             "[INFO] Loaded checkpoint with strict=False: "
             f"missing={len(incompatible.missing_keys)} unexpected={len(incompatible.unexpected_keys)}"
         )
+    print(f"[INFO] Validated checkpoint architecture: {architecture}")
     return model.to(device).eval()
 
 
@@ -54,6 +71,15 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument("--batch_size", type=int, default=2, help="Fixed exported ONNX batch size. Use 2 for batched CFG TensorRT inference.")
     parser.add_argument("--legacy-exporter", action="store_true", help="Use the legacy torch.onnx tracer instead of the dynamo exporter.")
     parser.add_argument("--allow-partial-ckpt", action="store_true", help="Load checkpoint with strict=False before exporting.")
+    parser.add_argument(
+        "--legacy-attention-contract",
+        choices=tuple(LEGACY_ATTENTION_CONTRACTS),
+        default=None,
+        help=(
+            "Required for checkpoints created before architecture contracts were recorded. "
+            "The selected contract must match explicit denoiser QK-normalization overrides."
+        ),
+    )
     parser.add_argument("overrides", nargs="*", help="Additional Hydra overrides, e.g. model.text_encoder.model_name=models/t5-base-local")
     return parser.parse_args()
 
@@ -76,7 +102,13 @@ def main() -> None:
             ],
         )
 
-    model = _load_model(cfg, args.ckpt_path, device=device, strict=not bool(args.allow_partial_ckpt))
+    model = _load_model(
+        cfg,
+        args.ckpt_path,
+        device=device,
+        strict=not bool(args.allow_partial_ckpt),
+        legacy_attention_contract=args.legacy_attention_contract,
+    )
     metadata = export_denoiser_step_onnx(
         model,
         output,

--- a/src/omg/generation/architecture.py
+++ b/src/omg/generation/architecture.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+
+MODEL_ARCHITECTURE_KEY = "omg_model_architecture"
+MODEL_ARCHITECTURE_FORMAT = "omg.model_architecture"
+MODEL_ARCHITECTURE_VERSION = 1
+
+LEGACY_ATTENTION_CONTRACTS = {
+    "none": {
+        "rotary_self_attention_qk_norm": False,
+        "cross_attention_qk_norm": False,
+    },
+    "cross-only": {
+        "rotary_self_attention_qk_norm": False,
+        "cross_attention_qk_norm": True,
+    },
+    "self-only": {
+        "rotary_self_attention_qk_norm": True,
+        "cross_attention_qk_norm": False,
+    },
+    "self-and-cross": {
+        "rotary_self_attention_qk_norm": True,
+        "cross_attention_qk_norm": True,
+    },
+}
+
+
+def build_model_architecture_contract(model: Any) -> dict[str, Any]:
+    denoiser = model.denoiser
+    return {
+        "format": MODEL_ARCHITECTURE_FORMAT,
+        "version": MODEL_ARCHITECTURE_VERSION,
+        "denoiser_type": f"{type(denoiser).__module__}.{type(denoiser).__qualname__}",
+        "frame_cond_injection": str(getattr(model, "frame_cond_injection", "")),
+        "attention": {
+            "rotary_self_attention_qk_norm": bool(
+                getattr(denoiser, "self_attention_qk_norm", False)
+            ),
+            "cross_attention_qk_norm": bool(
+                getattr(denoiser, "cross_attention_qk_norm", False)
+            ),
+        },
+    }
+
+
+def _validate_contract_shape(contract: Mapping[str, Any]) -> None:
+    if contract.get("format") != MODEL_ARCHITECTURE_FORMAT:
+        raise RuntimeError(
+            "Unsupported checkpoint architecture format: "
+            f"{contract.get('format')!r}; expected {MODEL_ARCHITECTURE_FORMAT!r}"
+        )
+    if int(contract.get("version", -1)) != MODEL_ARCHITECTURE_VERSION:
+        raise RuntimeError(
+            "Unsupported checkpoint architecture version: "
+            f"{contract.get('version')!r}; expected {MODEL_ARCHITECTURE_VERSION}"
+        )
+    attention = contract.get("attention")
+    if not isinstance(attention, Mapping):
+        raise RuntimeError("Checkpoint architecture contract is missing the attention mapping")
+    missing = {
+        "rotary_self_attention_qk_norm",
+        "cross_attention_qk_norm",
+    } - set(attention)
+    if missing:
+        raise RuntimeError(f"Checkpoint architecture attention contract is missing keys: {sorted(missing)}")
+
+
+def validate_checkpoint_architecture_contract(
+    checkpoint: Mapping[str, Any],
+    model: Any,
+    *,
+    legacy_attention_contract: str | None = None,
+) -> dict[str, Any]:
+    actual = build_model_architecture_contract(model)
+    recorded = checkpoint.get(MODEL_ARCHITECTURE_KEY)
+
+    if recorded is None:
+        if legacy_attention_contract is None:
+            choices = ", ".join(LEGACY_ATTENTION_CONTRACTS)
+            raise RuntimeError(
+                "Checkpoint has no OMG architecture contract. Attention normalization changes no parameter "
+                "shapes, so strict state-dict loading cannot detect this semantic mismatch. Re-run with "
+                f"--legacy-attention-contract {{{choices}}} and matching Hydra denoiser overrides."
+            )
+        if legacy_attention_contract not in LEGACY_ATTENTION_CONTRACTS:
+            raise ValueError(f"Unknown legacy attention contract: {legacy_attention_contract!r}")
+        expected_attention = LEGACY_ATTENTION_CONTRACTS[legacy_attention_contract]
+        source = f"legacy declaration {legacy_attention_contract!r}"
+    else:
+        if not isinstance(recorded, Mapping):
+            raise RuntimeError(f"Checkpoint {MODEL_ARCHITECTURE_KEY} must be a mapping")
+        _validate_contract_shape(recorded)
+        expected_attention = {
+            key: bool(recorded["attention"][key])
+            for key in (
+                "rotary_self_attention_qk_norm",
+                "cross_attention_qk_norm",
+            )
+        }
+        source = "checkpoint architecture contract"
+        for key in ("denoiser_type", "frame_cond_injection"):
+            if str(recorded.get(key, "")) != str(actual[key]):
+                raise RuntimeError(
+                    f"Instantiated model {key} does not match the checkpoint architecture contract: "
+                    f"expected={recorded.get(key)!r}, actual={actual[key]!r}"
+                )
+
+    if actual["attention"] != expected_attention:
+        raise RuntimeError(
+            "Instantiated denoiser attention semantics do not match the "
+            f"{source}: expected={expected_attention}, actual={actual['attention']}. "
+            "Set denoiser.self_attention_qk_norm and denoiser.cross_attention_qk_norm to the checkpoint's "
+            "training values before exporting."
+        )
+    return actual

--- a/src/omg/generation/denoisers/transformer.py
+++ b/src/omg/generation/denoisers/transformer.py
@@ -63,7 +63,14 @@ class RotaryPositionEmbedding(nn.Module):
 
 
 class RotarySelfAttention(nn.Module):
-    def __init__(self, hidden_dim: int, num_heads: int, dropout: float = 0.1, rope_base: float = 10000.0):
+    def __init__(
+        self,
+        hidden_dim: int,
+        num_heads: int,
+        dropout: float = 0.1,
+        rope_base: float = 10000.0,
+        qk_norm: bool = True,
+    ):
         super().__init__()
         if hidden_dim % num_heads != 0:
             raise ValueError(f"hidden_dim={hidden_dim} must be divisible by num_heads={num_heads}")
@@ -76,6 +83,7 @@ class RotarySelfAttention(nn.Module):
         self.rope = RotaryPositionEmbedding(self.head_dim, base=rope_base)
         self.out_proj = nn.Linear(self.hidden_dim, self.hidden_dim)
         self.dropout = float(dropout)
+        self.qk_norm = bool(qk_norm)
 
     def forward(self, x: torch.Tensor, key_padding_mask: torch.Tensor | None = None) -> torch.Tensor:
         batch_size, seq_len, _ = x.shape
@@ -86,9 +94,10 @@ class RotarySelfAttention(nn.Module):
         v = v.transpose(1, 2)
         q, k = self.rope.apply(q, k)
 
-        head_scale = math.sqrt(self.head_dim)
-        q = F.normalize(q.float(), dim=-1).to(dtype=q.dtype) * head_scale
-        k = F.normalize(k.float(), dim=-1).to(dtype=k.dtype) * head_scale
+        if self.qk_norm:
+            head_scale = math.sqrt(self.head_dim)
+            q = F.normalize(q.float(), dim=-1).to(dtype=q.dtype) * head_scale
+            k = F.normalize(k.float(), dim=-1).to(dtype=k.dtype) * head_scale
 
         attn_mask = None
         if key_padding_mask is not None:
@@ -265,10 +274,23 @@ def _qk_normalized_cross_attention(
 
 
 class RotaryTransformerEncoderLayer(nn.Module):
-    def __init__(self, hidden_dim: int, num_heads: int, dropout: float = 0.1, rope_base: float = 10000.0):
+    def __init__(
+        self,
+        hidden_dim: int,
+        num_heads: int,
+        dropout: float = 0.1,
+        rope_base: float = 10000.0,
+        self_attention_qk_norm: bool = True,
+    ):
         super().__init__()
         self.norm1 = nn.LayerNorm(hidden_dim)
-        self.attn = RotarySelfAttention(hidden_dim, num_heads, dropout=dropout, rope_base=rope_base)
+        self.attn = RotarySelfAttention(
+            hidden_dim,
+            num_heads,
+            dropout=dropout,
+            rope_base=rope_base,
+            qk_norm=self_attention_qk_norm,
+        )
         self.norm2 = nn.LayerNorm(hidden_dim)
         self.ff = nn.Sequential(
             nn.Linear(hidden_dim, hidden_dim * 4),
@@ -344,6 +366,8 @@ class MotionTransformerBlock(nn.Module):
         audio_local_attn_window: int = 8,
         human_motion_local_attn_window: int = 2,
         use_human_motion_local_attn: bool = False,
+        self_attention_qk_norm: bool = True,
+        cross_attention_qk_norm: bool = True,
     ):
         super().__init__()
         self.norm_cross = nn.LayerNorm(hidden_dim)
@@ -359,7 +383,9 @@ class MotionTransformerBlock(nn.Module):
             num_heads,
             dropout=dropout,
             rope_base=rope_base,
+            qk_norm=self_attention_qk_norm,
         )
+        self.cross_attention_qk_norm = bool(cross_attention_qk_norm)
         self.norm_ff = nn.LayerNorm(hidden_dim)
         ff_dim = int(round(hidden_dim * float(mlp_ratio)))
         self.ff = nn.Sequential(
@@ -501,12 +527,21 @@ class MotionTransformerBlock(nn.Module):
     ) -> torch.Tensor:
         context_key_padding = ~context_mask.bool()
         h = self.norm_cross(x)
-        cross = _qk_normalized_cross_attention(
-            self.cross_attn,
-            query=h,
-            context=context,
-            context_key_padding_mask=context_key_padding,
-        )
+        if self.cross_attention_qk_norm:
+            cross = _qk_normalized_cross_attention(
+                self.cross_attn,
+                query=h,
+                context=context,
+                context_key_padding_mask=context_key_padding,
+            )
+        else:
+            cross, _ = self.cross_attn(
+                query=h,
+                key=context,
+                value=context,
+                key_padding_mask=context_key_padding,
+                need_weights=False,
+            )
         x = x + self.dropout(cross)
         h = self.norm_self(x)
         x = x + self.dropout(self.self_attn(h, key_padding_mask=key_padding_mask))
@@ -554,6 +589,8 @@ class MotionTransformerDenoiser(BaseMotionDenoiser):
         audio_local_attn_window: int = 8,
         human_motion_local_attn_window: int = 2,
         use_human_motion_local_attn: bool = False,
+        self_attention_qk_norm: bool = True,
+        cross_attention_qk_norm: bool = True,
     ):
         super().__init__()
         self.hidden_dim = int(hidden_dim)
@@ -563,6 +600,8 @@ class MotionTransformerDenoiser(BaseMotionDenoiser):
         self.audio_local_attn_window = int(audio_local_attn_window)
         self.human_motion_local_attn_window = int(human_motion_local_attn_window)
         self.use_human_motion_local_attn = bool(use_human_motion_local_attn)
+        self.self_attention_qk_norm = bool(self_attention_qk_norm)
+        self.cross_attention_qk_norm = bool(cross_attention_qk_norm)
         self.time_embed = TimestepEmbedding(self.hidden_dim)
         self.input_proj = nn.Linear(self.input_dim + self.hidden_dim, self.hidden_dim)
         self.text_proj = nn.Linear(int(text_dim), self.hidden_dim)
@@ -580,6 +619,8 @@ class MotionTransformerDenoiser(BaseMotionDenoiser):
                     audio_local_attn_window=self.audio_local_attn_window,
                     human_motion_local_attn_window=self.human_motion_local_attn_window,
                     use_human_motion_local_attn=self.use_human_motion_local_attn,
+                    self_attention_qk_norm=self.self_attention_qk_norm,
+                    cross_attention_qk_norm=self.cross_attention_qk_norm,
                 )
                 for _ in range(int(num_layers))
             ]

--- a/src/omg/generation/export/__init__.py
+++ b/src/omg/generation/export/__init__.py
@@ -9,6 +9,8 @@ from omg.generation.export.onnx import (
     export_denoiser_step_onnx,
     load_export_metadata,
     validate_tensorrt_compatible_onnx,
+    validate_export_wrapper_parity,
+    validate_exported_onnx_parity,
     metadata_sidecar_path,
     save_export_metadata,
 )
@@ -24,6 +26,8 @@ __all__ = [
     "export_denoiser_step_onnx",
     "load_export_metadata",
     "validate_tensorrt_compatible_onnx",
+    "validate_export_wrapper_parity",
+    "validate_exported_onnx_parity",
     "metadata_sidecar_path",
     "save_export_metadata",
 ]

--- a/src/omg/generation/export/onnx.py
+++ b/src/omg/generation/export/onnx.py
@@ -9,7 +9,8 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
-from omg.generation.denoisers.transformer import RotarySelfAttention
+from omg.generation.architecture import build_model_architecture_contract
+from omg.generation.denoisers.transformer import MotionTransformerBlock, RotarySelfAttention
 
 EXPORT_METADATA_KEY = "omg_export_metadata"
 EXPORT_FORMAT = "omg.denoiser_step"
@@ -22,20 +23,26 @@ def _rotate_half_export(x: torch.Tensor) -> torch.Tensor:
 
 
 class TensorRTFriendlyMultiheadAttention(nn.Module):
-    def __init__(self, embed_dim: int, num_heads: int, bias: bool):
+    def __init__(self, embed_dim: int, num_heads: int, bias: bool, qk_norm: bool = False):
         super().__init__()
         self.embed_dim = int(embed_dim)
         self.num_heads = int(num_heads)
         if self.embed_dim % self.num_heads != 0:
             raise ValueError(f"embed_dim={embed_dim} must be divisible by num_heads={num_heads}")
         self.head_dim = self.embed_dim // self.num_heads
+        self.qk_norm = bool(qk_norm)
         self.q_proj = nn.Linear(self.embed_dim, self.embed_dim, bias=bias)
         self.k_proj = nn.Linear(self.embed_dim, self.embed_dim, bias=bias)
         self.v_proj = nn.Linear(self.embed_dim, self.embed_dim, bias=bias)
         self.out_proj = nn.Linear(self.embed_dim, self.embed_dim, bias=bias)
 
     @classmethod
-    def from_mha(cls, module: nn.MultiheadAttention) -> TensorRTFriendlyMultiheadAttention:
+    def from_mha(
+        cls,
+        module: nn.MultiheadAttention,
+        *,
+        qk_norm: bool = False,
+    ) -> TensorRTFriendlyMultiheadAttention:
         if module.kdim != module.embed_dim or module.vdim != module.embed_dim:
             raise ValueError("TensorRT diffusion export requires kdim == vdim == embed_dim for cross-attention")
         if module.bias_k is not None or module.bias_v is not None or module.add_zero_attn:
@@ -43,7 +50,12 @@ class TensorRTFriendlyMultiheadAttention(nn.Module):
         if module.in_proj_weight is None:
             raise ValueError("TensorRT diffusion export requires packed MultiheadAttention in_proj_weight")
 
-        converted = cls(module.embed_dim, module.num_heads, bias=module.in_proj_bias is not None)
+        converted = cls(
+            module.embed_dim,
+            module.num_heads,
+            bias=module.in_proj_bias is not None,
+            qk_norm=qk_norm,
+        )
         q_weight, k_weight, v_weight = module.in_proj_weight.detach().chunk(3, dim=0)
         converted.q_proj.weight.data.copy_(q_weight)
         converted.k_proj.weight.data.copy_(k_weight)
@@ -73,9 +85,10 @@ class TensorRTFriendlyMultiheadAttention(nn.Module):
         q = self.q_proj(query).reshape(batch_size, query_len, self.num_heads, self.head_dim).transpose(1, 2)
         k = self.k_proj(key).reshape(batch_size, key_len, self.num_heads, self.head_dim).transpose(1, 2)
         v = self.v_proj(value).reshape(batch_size, key_len, self.num_heads, self.head_dim).transpose(1, 2)
-        head_scale = float(self.head_dim) ** 0.5
-        q = F.normalize(q.float(), dim=-1).to(dtype=q.dtype) * head_scale
-        k = F.normalize(k.float(), dim=-1).to(dtype=k.dtype) * head_scale
+        if self.qk_norm:
+            head_scale = float(self.head_dim) ** 0.5
+            q = F.normalize(q.float(), dim=-1).to(dtype=q.dtype) * head_scale
+            k = F.normalize(k.float(), dim=-1).to(dtype=k.dtype) * head_scale
 
         attn_mask = None
         if key_padding_mask is not None:
@@ -88,13 +101,21 @@ class TensorRTFriendlyMultiheadAttention(nn.Module):
 
 
 class TensorRTFriendlyRotarySelfAttention(nn.Module):
-    def __init__(self, hidden_dim: int, num_heads: int, sequence_length: int, inv_freq: torch.Tensor):
+    def __init__(
+        self,
+        hidden_dim: int,
+        num_heads: int,
+        sequence_length: int,
+        inv_freq: torch.Tensor,
+        qk_norm: bool = True,
+    ):
         super().__init__()
         self.hidden_dim = int(hidden_dim)
         self.num_heads = int(num_heads)
         if self.hidden_dim % self.num_heads != 0:
             raise ValueError(f"hidden_dim={hidden_dim} must be divisible by num_heads={num_heads}")
         self.head_dim = self.hidden_dim // self.num_heads
+        self.qk_norm = bool(qk_norm)
         if self.head_dim % 2 != 0:
             raise ValueError(f"RoPE requires an even attention head dim, got {self.head_dim}")
         self.qkv = nn.Linear(self.hidden_dim, self.hidden_dim * 3)
@@ -120,6 +141,7 @@ class TensorRTFriendlyRotarySelfAttention(nn.Module):
             num_heads=module.num_heads,
             sequence_length=sequence_length,
             inv_freq=module.rope.inv_freq.detach(),
+            qk_norm=module.qk_norm,
         )
         converted.qkv.load_state_dict(module.qkv.state_dict())
         converted.out_proj.load_state_dict(module.out_proj.state_dict())
@@ -135,9 +157,10 @@ class TensorRTFriendlyRotarySelfAttention(nn.Module):
         sin = self.sin[:, :, :seq_len, :].to(dtype=q.dtype)
         q = (q * cos) + (_rotate_half_export(q) * sin)
         k = (k * cos) + (_rotate_half_export(k) * sin)
-        head_scale = float(self.head_dim) ** 0.5
-        q = F.normalize(q.float(), dim=-1).to(dtype=q.dtype) * head_scale
-        k = F.normalize(k.float(), dim=-1).to(dtype=k.dtype) * head_scale
+        if self.qk_norm:
+            head_scale = float(self.head_dim) ** 0.5
+            q = F.normalize(q.float(), dim=-1).to(dtype=q.dtype) * head_scale
+            k = F.normalize(k.float(), dim=-1).to(dtype=k.dtype) * head_scale
 
         attn_mask = None
         if key_padding_mask is not None:
@@ -153,6 +176,15 @@ class TensorRTFriendlyRotarySelfAttention(nn.Module):
 
 
 def _replace_export_attention(module: nn.Module, *, sequence_length: int) -> None:
+    if isinstance(module, MotionTransformerBlock):
+        module.cross_attn = TensorRTFriendlyMultiheadAttention.from_mha(
+            module.cross_attn,
+            qk_norm=module.cross_attention_qk_norm,
+        )
+        module.self_attn = TensorRTFriendlyRotarySelfAttention.from_rotary_self_attention(
+            module.self_attn,
+            sequence_length=sequence_length,
+        )
     for name, child in list(module.named_children()):
         if isinstance(child, nn.MultiheadAttention):
             setattr(module, name, TensorRTFriendlyMultiheadAttention.from_mha(child))
@@ -234,11 +266,8 @@ class DenoiserStepExportModel(nn.Module):
             conditions[mask_key] = mask
         return frame_cond
 
-    def forward(
+    def _prepare_conditions(
         self,
-        x: torch.Tensor,
-        timesteps: torch.Tensor,
-        valid_mask: torch.Tensor,
         history_features: torch.Tensor,
         text_context: torch.Tensor,
         text_mask: torch.Tensor,
@@ -246,7 +275,7 @@ class DenoiserStepExportModel(nn.Module):
         audio_mask: torch.Tensor | None = None,
         human_motion: torch.Tensor | None = None,
         human_motion_mask: torch.Tensor | None = None,
-    ) -> torch.Tensor:
+    ) -> dict[str, torch.Tensor]:
         history_norm = (history_features - self.feature_mean.to(history_features)) / self.feature_std.to(history_features)
         history_tokens = self.history_projector(history_norm)
         extra_tokens = [history_tokens]
@@ -282,11 +311,119 @@ class DenoiserStepExportModel(nn.Module):
             )
         if frame_cond is not None:
             conditions["frame_cond"] = frame_cond
+        return conditions
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        timesteps: torch.Tensor,
+        valid_mask: torch.Tensor,
+        history_features: torch.Tensor,
+        text_context: torch.Tensor,
+        text_mask: torch.Tensor,
+        audio_features: torch.Tensor | None = None,
+        audio_mask: torch.Tensor | None = None,
+        human_motion: torch.Tensor | None = None,
+        human_motion_mask: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        conditions = self._prepare_conditions(
+            history_features,
+            text_context,
+            text_mask,
+            audio_features,
+            audio_mask,
+            human_motion,
+            human_motion_mask,
+        )
         pred = self.denoiser(x, timesteps, conditions, valid_mask=None)
         # The exported planner contract samples fixed full chunks. Keep
         # valid_mask as an ABI input without routing it through attention masks.
         valid_mask_anchor = valid_mask.to(dtype=pred.dtype).sum() * 0.0
         return pred + valid_mask_anchor
+
+
+def validate_export_wrapper_parity(
+    motion_model: nn.Module,
+    wrapper: DenoiserStepExportModel,
+    args: tuple[torch.Tensor, ...],
+    kwargs: dict[str, torch.Tensor],
+    *,
+    atol: float = 1.0e-4,
+    rtol: float = 1.0e-4,
+) -> dict[str, float]:
+    x, timesteps, _, history_features, text_context, text_mask = args
+    conditions = wrapper._prepare_conditions(
+        history_features,
+        text_context,
+        text_mask,
+        kwargs.get("audio_features"),
+        kwargs.get("audio_mask"),
+        kwargs.get("human_motion"),
+        kwargs.get("human_motion_mask"),
+    )
+    with torch.no_grad():
+        expected = motion_model.denoiser(x, timesteps, conditions, valid_mask=None)
+        actual = wrapper(*args, **kwargs)
+    delta = (actual.float() - expected.float()).detach()
+    metrics = {
+        "max_abs": float(delta.abs().max().cpu()),
+        "mean_abs": float(delta.abs().mean().cpu()),
+        "rmse": float(delta.square().mean().sqrt().cpu()),
+    }
+    if not torch.allclose(actual, expected, atol=float(atol), rtol=float(rtol)):
+        raise RuntimeError(
+            "TensorRT export wrapper changed the training denoiser semantics: "
+            f"metrics={metrics}, atol={atol}, rtol={rtol}"
+        )
+    return metrics
+
+
+def validate_exported_onnx_parity(
+    onnx_path: str | Path,
+    wrapper: DenoiserStepExportModel,
+    args: tuple[torch.Tensor, ...],
+    kwargs: dict[str, torch.Tensor],
+    *,
+    max_abs_tolerance: float = 5.0e-3,
+    rmse_tolerance: float = 5.0e-4,
+) -> dict[str, Any]:
+    import numpy as np
+    import onnxruntime as ort
+
+    with torch.no_grad():
+        expected = wrapper(*args, **kwargs).detach().float().cpu().numpy()
+    names = [
+        "x",
+        "timesteps",
+        "valid_mask",
+        "history_features",
+        "text_context",
+        "text_mask",
+    ]
+    feeds = {name: value.detach().cpu().numpy() for name, value in zip(names, args, strict=True)}
+    feeds.update({name: value.detach().cpu().numpy() for name, value in kwargs.items()})
+
+    available = ort.get_available_providers()
+    providers = ["CUDAExecutionProvider", "CPUExecutionProvider"]
+    providers = [provider for provider in providers if provider in available]
+    if not providers:
+        raise RuntimeError(f"No supported ONNX Runtime provider is available; found {available}")
+    session = ort.InferenceSession(str(onnx_path), providers=providers)
+    accepted = {value.name for value in session.get_inputs()}
+    actual = session.run(None, {name: value for name, value in feeds.items() if name in accepted})[0]
+    delta = actual.astype(np.float64) - expected.astype(np.float64)
+    metrics: dict[str, Any] = {
+        "provider": session.get_providers()[0],
+        "max_abs": float(np.abs(delta).max()),
+        "mean_abs": float(np.abs(delta).mean()),
+        "rmse": float(np.sqrt(np.square(delta).mean())),
+    }
+    if metrics["max_abs"] > float(max_abs_tolerance) or metrics["rmse"] > float(rmse_tolerance):
+        raise RuntimeError(
+            "Exported ONNX changed the export-wrapper semantics: "
+            f"metrics={metrics}, max_abs_tolerance={max_abs_tolerance}, rmse_tolerance={rmse_tolerance}"
+        )
+    return metrics
 
 
 def _infer_text_dim(model: nn.Module) -> int:
@@ -356,6 +493,7 @@ def build_export_metadata(
         "batch_size": int(batch_size),
         "stats_path": _as_repo_or_abs_path(getattr(representation, "stats_path", None)),
         "kinematics_path": _as_repo_or_abs_path(getattr(representation.kinematics, "kinematics_path", None)),
+        "model_architecture": build_model_architecture_contract(model),
     }
     return metadata
 
@@ -436,6 +574,10 @@ def export_denoiser_step_onnx(
     text_len: int | None = None,
     batch_size: int = 2,
     dynamo: bool = True,
+    wrapper_parity_atol: float = 1.0e-4,
+    wrapper_parity_rtol: float = 1.0e-4,
+    onnx_parity_max_abs: float = 5.0e-3,
+    onnx_parity_rmse: float = 5.0e-4,
 ) -> dict[str, Any]:
     if dynamo and int(opset) < 18:
         raise ValueError("The torch dynamo ONNX exporter requires opset >= 18")
@@ -492,6 +634,14 @@ def export_denoiser_step_onnx(
         kwargs["human_motion"] = torch.randn(batch, seq_len, human_motion_dim, device=device, dtype=torch.float32)
         kwargs["human_motion_mask"] = torch.ones(batch, seq_len, device=device, dtype=torch.bool)
         input_names.extend(["human_motion", "human_motion_mask"])
+    wrapper_metrics = validate_export_wrapper_parity(
+        model,
+        wrapper,
+        args,
+        kwargs,
+        atol=wrapper_parity_atol,
+        rtol=wrapper_parity_rtol,
+    )
     with torch.no_grad():
         torch.onnx.export(
             wrapper,
@@ -504,6 +654,29 @@ def export_denoiser_step_onnx(
             do_constant_folding=True,
             dynamo=bool(dynamo),
         )
+    try:
+        onnx_metrics = validate_exported_onnx_parity(
+            output,
+            wrapper,
+            args,
+            kwargs,
+            max_abs_tolerance=onnx_parity_max_abs,
+            rmse_tolerance=onnx_parity_rmse,
+        )
+    except Exception:
+        output.unlink(missing_ok=True)
+        Path(str(output) + ".data").unlink(missing_ok=True)
+        raise
+    metadata["parity_validation"] = {
+        "training_denoiser_to_export_wrapper": wrapper_metrics,
+        "export_wrapper_to_onnx": onnx_metrics,
+        "thresholds": {
+            "wrapper_atol": float(wrapper_parity_atol),
+            "wrapper_rtol": float(wrapper_parity_rtol),
+            "onnx_max_abs": float(onnx_parity_max_abs),
+            "onnx_rmse": float(onnx_parity_rmse),
+        },
+    }
     save_export_metadata(output, metadata)
     embed_export_metadata(output, metadata)
     validate_tensorrt_compatible_onnx(output)

--- a/src/omg/generation/models/motion_generator.py
+++ b/src/omg/generation/models/motion_generator.py
@@ -9,6 +9,8 @@ import torch.nn as nn
 from hydra.utils import instantiate
 from omegaconf import DictConfig
 
+from omg.generation.architecture import MODEL_ARCHITECTURE_KEY, build_model_architecture_contract
+
 
 FRAME_COND_INJECTION_MODES = {
     "sum_to_time",
@@ -156,6 +158,9 @@ class MotionGenerator(pl.LightningModule):
                 f"model={self.frame_cond_injection!r}, denoiser={actual!r}. "
                 "Instantiate the denoiser with the same mode instead of changing the mode after construction."
             )
+
+    def on_save_checkpoint(self, checkpoint: dict[str, Any]) -> None:
+        checkpoint[MODEL_ARCHITECTURE_KEY] = build_model_architecture_contract(self)
 
     def _configure_denoiser_frame_condition_grads(self) -> None:
         separate_mode = self.frame_cond_injection == "separate_to_h"

--- a/tests/generation/test_checkpoint_architecture.py
+++ b/tests/generation/test_checkpoint_architecture.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from omg.generation.architecture import (
+    MODEL_ARCHITECTURE_KEY,
+    build_model_architecture_contract,
+    validate_checkpoint_architecture_contract,
+)
+from omg.generation.models.motion_generator import MotionGenerator
+
+
+def _model(*, self_qk_norm: bool, cross_qk_norm: bool):
+    denoiser = SimpleNamespace(
+        self_attention_qk_norm=self_qk_norm,
+        cross_attention_qk_norm=cross_qk_norm,
+    )
+    return SimpleNamespace(
+        denoiser=denoiser,
+        frame_cond_injection="per_layer_film",
+    )
+
+
+def test_checkpoint_hook_records_attention_architecture():
+    model = _model(self_qk_norm=False, cross_qk_norm=True)
+    checkpoint = {}
+    MotionGenerator.on_save_checkpoint(model, checkpoint)
+    assert checkpoint[MODEL_ARCHITECTURE_KEY]["attention"] == {
+        "rotary_self_attention_qk_norm": False,
+        "cross_attention_qk_norm": True,
+    }
+
+
+def test_recorded_checkpoint_contract_validates_matching_model():
+    model = _model(self_qk_norm=True, cross_qk_norm=True)
+    checkpoint = {MODEL_ARCHITECTURE_KEY: build_model_architecture_contract(model)}
+    assert validate_checkpoint_architecture_contract(checkpoint, model)["attention"] == {
+        "rotary_self_attention_qk_norm": True,
+        "cross_attention_qk_norm": True,
+    }
+
+
+def test_recorded_checkpoint_contract_rejects_semantic_mismatch():
+    trained = _model(self_qk_norm=False, cross_qk_norm=True)
+    current = _model(self_qk_norm=True, cross_qk_norm=True)
+    checkpoint = {MODEL_ARCHITECTURE_KEY: build_model_architecture_contract(trained)}
+    with pytest.raises(RuntimeError, match="do not match"):
+        validate_checkpoint_architecture_contract(checkpoint, current)
+
+
+def test_legacy_checkpoint_requires_explicit_attention_contract():
+    model = _model(self_qk_norm=False, cross_qk_norm=True)
+    with pytest.raises(RuntimeError, match="--legacy-attention-contract"):
+        validate_checkpoint_architecture_contract({}, model)
+
+
+def test_legacy_cross_only_contract_accepts_matching_model():
+    model = _model(self_qk_norm=False, cross_qk_norm=True)
+    contract = validate_checkpoint_architecture_contract(
+        {},
+        model,
+        legacy_attention_contract="cross-only",
+    )
+    assert contract["attention"] == {
+        "rotary_self_attention_qk_norm": False,
+        "cross_attention_qk_norm": True,
+    }
+
+
+def test_legacy_contract_rejects_wrong_instantiated_architecture():
+    model = _model(self_qk_norm=True, cross_qk_norm=True)
+    with pytest.raises(RuntimeError, match="do not match"):
+        validate_checkpoint_architecture_contract(
+            {},
+            model,
+            legacy_attention_contract="cross-only",
+        )

--- a/tests/generation/test_export_onnx_contract.py
+++ b/tests/generation/test_export_onnx_contract.py
@@ -2,9 +2,14 @@ from __future__ import annotations
 
 import torch
 import torch.nn as nn
+import pytest
 
 from omg.generation.denoisers.transformer import _rotate_half
-from omg.generation.export import DenoiserStepExportModel, build_export_metadata
+from omg.generation.export import (
+    DenoiserStepExportModel,
+    build_export_metadata,
+    validate_export_wrapper_parity,
+)
 
 
 class _FakeKinematics:
@@ -83,6 +88,33 @@ def test_denoiser_step_export_wrapper_contract():
     assert pred.shape == (1, 5, 3)
 
 
+def _wrapper_parity_inputs():
+    return (
+        torch.randn(1, 5, 3),
+        torch.zeros(1, 5, dtype=torch.long),
+        torch.ones(1, 5, dtype=torch.bool),
+        torch.randn(1, 2, 3),
+        torch.randn(1, 7, 6),
+        torch.ones(1, 7, dtype=torch.bool),
+    )
+
+
+def test_export_wrapper_parity_accepts_equivalent_graph():
+    model = _FakeModel().eval()
+    wrapper = DenoiserStepExportModel(model).eval()
+    metrics = validate_export_wrapper_parity(model, wrapper, _wrapper_parity_inputs(), {})
+    assert metrics["max_abs"] == 0.0
+
+
+def test_export_wrapper_parity_rejects_semantic_drift():
+    model = _FakeModel().eval()
+    wrapper = DenoiserStepExportModel(model).eval()
+    with torch.no_grad():
+        wrapper.denoiser.output.weight.add_(1.0)
+    with pytest.raises(RuntimeError, match="changed the training denoiser semantics"):
+        validate_export_wrapper_parity(model, wrapper, _wrapper_parity_inputs(), {})
+
+
 def test_build_export_metadata_contract():
     metadata = build_export_metadata(_FakeModel(), opset=17, text_len=7)
     assert metadata["format"] == "omg.denoiser_step"
@@ -128,7 +160,14 @@ def test_rotate_half_matches_stack_flatten():
 
 
 
-def test_tensorrt_compatible_denoiser_matches_transformer_attention():
+@pytest.mark.parametrize(
+    ("self_qk_norm", "cross_qk_norm"),
+    [(False, False), (False, True), (True, False), (True, True)],
+)
+def test_tensorrt_compatible_denoiser_matches_transformer_attention(
+    self_qk_norm: bool,
+    cross_qk_norm: bool,
+):
     from omg.generation.denoisers.transformer import MotionTransformerDenoiser, RotarySelfAttention
     from omg.generation.export.onnx import (
         TensorRTFriendlyMultiheadAttention,
@@ -144,6 +183,8 @@ def test_tensorrt_compatible_denoiser_matches_transformer_attention():
         num_heads=2,
         text_dim=10,
         dropout=0.0,
+        self_attention_qk_norm=self_qk_norm,
+        cross_attention_qk_norm=cross_qk_norm,
     ).eval()
     converted = make_tensorrt_compatible_denoiser(denoiser, sequence_length=5).eval()
 
@@ -151,6 +192,9 @@ def test_tensorrt_compatible_denoiser_matches_transformer_attention():
     assert not any(isinstance(module, RotarySelfAttention) for module in converted.modules())
     assert any(isinstance(module, TensorRTFriendlyMultiheadAttention) for module in converted.modules())
     assert any(isinstance(module, TensorRTFriendlyRotarySelfAttention) for module in converted.modules())
+    converted_block = converted.layers[0]
+    assert converted_block.self_attn.qk_norm is self_qk_norm
+    assert converted_block.cross_attn.qk_norm is cross_qk_norm
 
     x = torch.randn(1, 5, 6)
     timesteps = torch.zeros(1, 5, dtype=torch.long)


### PR DESCRIPTION
## What changed

- record the attention architecture in newly written checkpoints
- make rotary self-attention and cross-attention QK normalization explicit config fields
- require legacy checkpoints to declare one of four attention contracts
- preserve those flags in the TensorRT-compatible attention conversion
- compare the training denoiser, export wrapper, and emitted ONNX numerically
- delete an emitted ONNX graph when parity validation fails
- store architecture and parity evidence in ONNX metadata

## Root cause

Attention QK normalization changes no state-dict keys or tensor shapes. An older
checkpoint trained with cross-attention normalization only could therefore load
strictly into a newer self-and-cross architecture and export successfully while
silently changing its motion semantics.

## Impact

New checkpoints are self-describing. Legacy exports fail closed until their
training attention contract is declared explicitly and matched by the Hydra
denoiser configuration. This prevents a clean-looking but semantically invalid
ONNX artifact from entering checkpoint comparison or rollout evaluation.

## Validation

- `153 passed` in the complete test suite
- real 100M 170k legacy checkpoint exported on A100-4-2 with `cross-only`
- training denoiser -> export wrapper: RMSE `1.97e-7`, max abs `1.91e-6`
- export wrapper -> ONNX CUDA: RMSE `2.84e-4`, max abs `2.05e-3`
- exported external weights match the known-good Friday artifact SHA256
  `016a151d5d821fc7a8eec7e3d64dfd9da69d0f8cd4da157b9d36399ccaaaf087`
- missing legacy declaration: rejected before export, no artifact retained
- mismatched declaration/config: rejected before export, no artifact retained
